### PR TITLE
feat/observation-refactor

### DIFF
--- a/illuminate/observation/http.py
+++ b/illuminate/observation/http.py
@@ -20,6 +20,16 @@ class HTTPObservation(Observation):
     Observation class and implements observe method.
     """
 
+    def __hash__(self) -> int:
+        """
+        HTTPObservation object hash value.
+
+        :return: int
+        """
+        body = self.configuration.get("body")
+        method = self.configuration.get("method")
+        return hash(f"{method}|{self.url}|:{body}")
+
     def __init__(
         self,
         url: str,

--- a/illuminate/observation/http.py
+++ b/illuminate/observation/http.py
@@ -58,6 +58,11 @@ class HTTPObservation(Observation):
 
     @property
     def allowed(self) -> bool:
+        """
+        Checks if HTTP URL is allowed to be requested.
+
+        :return: bool
+        """
         for allowed in self._allowed:
             if self.url.startswith(allowed):
                 return True

--- a/illuminate/observation/http.py
+++ b/illuminate/observation/http.py
@@ -41,7 +41,7 @@ class HTTPObservation(Observation):
         :param callback: Async function/method that will manipulate response
         object and yield Exporter, Finding and Observation objects
         """
-        self.url = url
+        super().__init__(url)
         self._allowed = allowed
         self._callback = callback
         self.configuration = kwargs

--- a/illuminate/observation/observation.py
+++ b/illuminate/observation/observation.py
@@ -12,6 +12,17 @@ class Observation(IObservation):
     method observe must be implemented in a child class.
     """
 
+    def __hash__(self):
+        """
+        Observation object hash value.
+
+        :return: None
+        :raises BasicObservationException:
+        """
+        raise BasicObservationException(
+            "Property hash must be implemented in child class"
+        )
+
     def __init__(self, url: Any):
         """
         Observation's __init__ method.

--- a/illuminate/observation/observation.py
+++ b/illuminate/observation/observation.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from illuminate.exceptions import BasicObservationException
 from illuminate.interface import IObservation
 
@@ -7,6 +11,14 @@ class Observation(IObservation):
     Observation class, reads data from the source. Class must be inherited and
     method observe must be implemented in a child class.
     """
+
+    def __init__(self, url: Any):
+        """
+        Observation's __init__ method.
+
+        :param url: Data's URL
+        """
+        self.url = url
 
     async def observe(self, *args, **kwargs):
         """

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -13,5 +13,5 @@ class TestObservation:
         When: calling observe method
         Expected: BasicObservationException is raised
         """
-        observer = Observation()
+        observer = Observation("https://www.example.com")
         observer.observe()

--- a/tests/test_observation_http.py
+++ b/tests/test_observation_http.py
@@ -7,6 +7,7 @@ from tornado.httpclient import HTTPClientError
 from tornado.httpclient import HTTPRequest
 from tornado.httpclient import HTTPResponse
 
+from illuminate import __version__
 from illuminate.exceptions import BasicObservationException
 from illuminate.observation import HTTPObservation
 
@@ -43,6 +44,81 @@ class TestSQLExporterClass:
         future = asyncio.Future()
         future.set_result(_side_effect)
         mocker.patch(TestSQLExporterClass.function, side_effect=_side_effect)
+
+    def test_hash_implementation_with_same_configuration(self):
+        """
+        Given: HTTPObservations are initialized with different URLs and
+        using the same configuration dict
+        When: Comparing hash values of HTTPObservation objects
+        Expected: They are not the same
+        """
+        config = {
+            "auth_username": None,
+            "auth_password": None,
+            "connect_timeout": 10.0,
+            "body": None,
+            "headers": None,
+            "method": "GET",
+            "request_timeout": 10.0,
+            "user_agent": f"Illuminate-bot/{__version__}",
+            "validate_cert": False,
+        }
+        observation_1 = HTTPObservation(
+            "https://example.com/api/v1",
+            allowed=(self.url,),
+            callback=int,
+            **config,
+        )
+        observation_2 = HTTPObservation(
+            "https://example.com/api/v2",
+            allowed=(self.url,),
+            callback=int,
+            **config,
+        )
+        assert hash(observation_1) != hash(observation_2)
+
+    def test_hash_implementation_with_same_url(self):
+        """
+        Given: HTTPObservations are initialized with same URLs and
+        using the different configuration dict
+        When: Comparing hash values of HTTPObservation objects
+        Expected: They are not the same
+        """
+        config_1 = {
+            "auth_username": None,
+            "auth_password": None,
+            "connect_timeout": 10.0,
+            "body": {"measurement": "°C"},
+            "headers": None,
+            "method": "POST",
+            "request_timeout": 10.0,
+            "user_agent": f"Illuminate-bot/{__version__}",
+            "validate_cert": False,
+        }
+        config_2 = {
+            "auth_username": None,
+            "auth_password": None,
+            "connect_timeout": 10.0,
+            "body": {"measurement": "K"},
+            "headers": None,
+            "method": "POST",
+            "request_timeout": 10.0,
+            "user_agent": f"Illuminate-bot/{__version__}",
+            "validate_cert": False,
+        }
+        observation_1 = HTTPObservation(
+            "https://example.com/api/v1",
+            allowed=(self.url,),
+            callback=int,
+            **config_1,
+        )
+        observation_2 = HTTPObservation(
+            "https://example.com/apiv1",
+            allowed=(self.url,),
+            callback=int,
+            **config_2,
+        )
+        assert hash(observation_1) != hash(observation_2)
 
     def test_not_allowed(self):
         """


### PR DESCRIPTION
## Type of PR
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (change outside the source code)
## PR Requirements
- [x] I have followed instructions in the [**CONTRIBUTING**](https://github.com/nikolamilojica/illuminate/blob/develop/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] My change requires to be covered with tests and type hints.
  - [x] I have added tests and type hints to cover my change.
    - [x] All new and existing tests passed locally. Coverage did not drop more than 5% compared to `develop` branch.
### Additional notes
___
<!--- Add any additional notes here: -->
Code refactor and introduction of a custom hash function that will level all future Observation subclasses to an integer value, allowing an easy way to check if Observation object was already initiated with given parameters.