### PR TITLE
fix/loguru-message-sanitization

### DIFF
--- a/illuminate/manager/manager.py
+++ b/illuminate/manager/manager.py
@@ -374,9 +374,10 @@ class Manager(IManager):
                 async for _item in result:
                     await self.__router(_item)
         except Exception:  # noqa
-            stack = f"<red>{traceback.format_exc().strip()}</red>"
+            stack = traceback.format_exc().strip().replace("<", "\\<")
             logger.opt(colors=True).warning(
-                f"Observation callback throws the following exception\n{stack}"
+                "Observation callback throws the following exception\n"
+                f"<red>{stack}</red>"
             )
 
     async def __observation_switch(self, item: Observation) -> None:

--- a/tests/exception/__init__.py
+++ b/tests/exception/__init__.py
@@ -1,0 +1,1 @@
+from .exception import TestANSIException

--- a/tests/exception/exception.py
+++ b/tests/exception/exception.py
@@ -1,0 +1,10 @@
+class TestANSIException(Exception):
+    """
+    Test Exception with ANSI tag look
+    a like message.
+    """
+
+    message = "\n<string>\n"
+
+    def __init__(self, message=None):
+        super().__init__(message or self.message)


### PR DESCRIPTION
## Type of PR
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] None-feature (non-breaking change which doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (change outside the source code)
## PR Requirements
- [x] I have followed instructions in the [**CONTRIBUTING**](https://github.com/nikolamilojica/illuminate/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change requires to be covered with type hints.
  - [ ] I have updated type hints accordingly.
- [x] My change requires to be covered with tests.
  - [x] I have added tests to cover my change.
    - [x] All new and existing tests passed locally. Coverage did not drop more than 5% compared to `master` branch.
### Additional notes
___
<!--- Add any additional notes here: -->
Fix an issue with Loguru color formatting when a quasi-ANSI tag appears in the exception message, blocking the async loop.